### PR TITLE
Bump to Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
     }
   },
   "require": {
-    "illuminate/console": "~5.5",
-    "illuminate/filesystem": "~5.5",
+    "illuminate/console": "~5.4",
+    "illuminate/filesystem": "~5.4",
     "symfony/process": "~3.3"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
     }
   },
   "require": {
-    "illuminate/console": "~5.4",
-    "illuminate/filesystem": "~5.4",
+    "illuminate/console": "~5.5",
+    "illuminate/filesystem": "~5.5",
     "symfony/process": "~3.3"
   },
   "require-dev": {


### PR DESCRIPTION
Since the development for version 9 is early and you already have the requirement for PHP 7.*, might as well go with the latest LTS release of Laravel. I will also be submitting similar PR's for Sage and Sage-Lib.

> Laravel 5.5 continues the improvements made in Laravel 5.4 by adding package auto-detection, API resources / transformations, auto-registration of console commands, queued job chaining, queued job rate limiting, time based job attempts, renderable mailables, renderable and reportable exceptions, more consistent exception handling, database testing improvements, simpler custom validation rules, React front-end presets, Route::view and Route::redirect methods, "locks" for the Memcached and Redis cache drivers, on-demand notifications, headless Chrome support in Dusk, convenient Blade shortcuts, improved trusted proxy support, and more.

You can view the [Release Notes for 5.5 (LTS)](https://laravel.com/docs/5.5/releases#laravel-5.5) of which, a couple should be of interest for the installer. 

- Package Discovery during Composer installs. 
- Frontend Presets for Bootstrap, React, Zurb Foundation, Bulma, UIKit 3, Primer CSS, or roll your own. There are numerous resources for this already.

