### PR TITLE
escapeshellarg

### DIFF
--- a/src/ComposerScript.php
+++ b/src/ComposerScript.php
@@ -20,7 +20,7 @@ class ComposerScript
 
     public static function postCreateProject(Event $event)
     {
-        $sage = dirname(__DIR__).'/bin/sage';
+        $sage = escapeshellarg(dirname(__DIR__).'/bin/sage');
         (new static($event))
             ->validate()
             ->run(new Process(sprintf('php %s %s', $sage, 'meta')))


### PR DESCRIPTION
Escape correctly the sage bin path since project's folder can have spaces in them which prevents the post-create-project-cmd composer script to run.