### PR TITLE
Update Sage primary color to new Roots brand

### DIFF
--- a/src/Presets/stubs/Bootstrap/styles/common/_variables.scss
+++ b/src/Presets/stubs/Bootstrap/styles/common/_variables.scss
@@ -2,5 +2,5 @@
 @import "~bootstrap/scss/functions";
 
 $theme-colors: (
-  primary: #27ae60
+  primary: #525ddc
 );

--- a/src/Presets/stubs/Bulma/styles/common/_variables.scss
+++ b/src/Presets/stubs/Bulma/styles/common/_variables.scss
@@ -1,5 +1,5 @@
 /** Colors */
-$primary:               #27ae60;
+$primary:               #525ddc;
 
 /** Box Model  */
 $spacer:                2rem;

--- a/src/Presets/stubs/Foundation/styles/common/_variables.scss
+++ b/src/Presets/stubs/Foundation/styles/common/_variables.scss
@@ -1,6 +1,6 @@
 /** Colors */
 $foundation-palette: (
-  primary: #27ae60,
+  primary: #525ddc,
   secondary: #1866ff,
   success: #3adb76,
   warning: #ffae00,

--- a/src/Presets/stubs/None/styles/common/_variables.scss
+++ b/src/Presets/stubs/None/styles/common/_variables.scss
@@ -1,5 +1,5 @@
 /** Colors */
-$brand-primary:         #27ae60;
+$brand-primary:         #525ddc;
 
 /** Box Model  */
 $spacer:                2rem;

--- a/src/Presets/stubs/Tachyons/styles/common/_variables.scss
+++ b/src/Presets/stubs/Tachyons/styles/common/_variables.scss
@@ -1,5 +1,5 @@
 /** Colors */
-$brand-primary:         #27ae60;
+$brand-primary:         #525ddc;
 
 /** Box Model  */
 $spacer:                2rem;


### PR DESCRIPTION
Just noticed that the Sage installer doesn’t have the updated Roots colour. 

Related: roots/sage#2055

Resolves #19 