### PR TITLE
Re-enable CSS sourcemaps for Tailwind preset

### DIFF
--- a/src/Presets/stubs/Tailwind/build/webpack.config.preset.js
+++ b/src/Presets/stubs/Tailwind/build/webpack.config.preset.js
@@ -29,7 +29,7 @@ module.exports = {
           fallback: 'style',
           use: [
             { loader: 'cache' },
-            { loader: 'css', options: { sourceMap: false } },
+            { loader: 'css', options: { sourceMap: true } },
             {
               loader: 'postcss',
               options: {
@@ -37,16 +37,16 @@ module.exports = {
                   ? 'postcss-safe-parser'
                   : undefined,
                 plugins: postcssPlugins,
-                sourceMap: false,
+                sourceMap: true,
               },
             },
             {
               loader: 'resolve-url',
-              options: { silent: true, sourceMap: false },
+              options: { silent: true, sourceMap: true },
             },
             {
               loader: 'sass',
-              options: { sourceComments: true, sourceMap: false },
+              options: { sourceComments: true, sourceMap: true },
             },
           ],
         }),


### PR DESCRIPTION
We disabled these since it throws an unnecessary warning in development and they aren't needed for Tailwind since it is generating CSS. There is a side effect though: image URLs don't resolve in the CSS anymore — which is not good at all. We can leave the silent option enabled for resolve-url-loader so the warning doesn't show.