### PR TITLE
Remove reference to Sage's package.json stylelint config

### DIFF
--- a/src/Presets/Preset.php
+++ b/src/Presets/Preset.php
@@ -121,11 +121,6 @@ abstract class Preset
             $packages['devDependencies']['tailwindcss']
         );
 
-        /** Remove preset specific at-rules */
-        $ignoreAtRules =& $packages['stylelint']['rules']['at-rule-no-unknown'][1]['ignoreAtRules'];
-        $presetAtRules = ['tailwind', 'apply', 'responsive', 'variants', 'screen'];
-        $ignoreAtRules = array_values(array_diff($ignoreAtRules, $presetAtRules));
-
         return $packages;
     }
 

--- a/src/Presets/Tailwind.php
+++ b/src/Presets/Tailwind.php
@@ -9,16 +9,6 @@ class Tailwind extends Preset
     {
         $packages['devDependencies']['tailwindcss'] = '^0.6.5';
 
-        /** Add Tailwind specific at-rules */
-        $ignoreAtRules =& $packages['stylelint']['rules']['at-rule-no-unknown'][1]['ignoreAtRules'];
-        $tailwindAtRules = ['tailwind', 'apply', 'responsive', 'variants', 'screen'];
-
-        foreach ($tailwindAtRules as $rule) {
-            if (!in_array($rule, $ignoreAtRules)) {
-                $ignoreAtRules[] = $rule;
-            }
-        }
-
         return $packages;
     }
 }


### PR DESCRIPTION
Sage moved the Stylelint config from `package.json` to `.stylelintrc.js` (https://github.com/roots/sage/pull/2076), but sage-installer currently attempts to directly modify Sage's Stylelint rules in `package.json`. This PR removes that direct reference.

sage-installer only used this to add / remove Tailwind's custom at-rules. We'll just add them directly to Sage's new Stylelint config instead (reference to follow).

Related bug report: https://discourse.roots.io/t/fresh-build-of-sage-dev-master-failing-with-stylelint-error/14225