### PR TITLE
Default `publicPath` to `/app/themes/<your-theme-name>`

### DIFF
--- a/src/Console/Commands/ConfigCommand.php
+++ b/src/Console/Commands/ConfigCommand.php
@@ -24,6 +24,8 @@ class ConfigCommand extends Command
         parent::configure();
         $this->configFile = "{$this->root}/resources/assets/config.json";
         $this->config = json_decode(file_get_contents($this->configFile), true);
+        $this->config['publicPath'] = '/app/themes/' . basename($this->root);
+
         $this->addOption(
             'url',
             null,


### PR DESCRIPTION
When creating new projects via `$ composer create-project roots/sage <your-theme-name>`, default `publicPath` to `/app/themes/<your-theme-name>`.