### PR TITLE
Add Tailwind 2’s peer dependencies to preset

### DIFF
--- a/src/Presets/Preset.php
+++ b/src/Presets/Preset.php
@@ -118,7 +118,9 @@ abstract class Preset
             $packages['dependencies']['bulma'],
             $packages['dependencies']['tachyons-sass'],
             $packages['dependencies']['foundation-sites'],
-            $packages['devDependencies']['tailwindcss']
+            $packages['devDependencies']['tailwindcss'],
+            $packages['devDependencies']['postcss'],
+            $packages['devDependencies']['autoprefixer']
         );
 
         return $packages;

--- a/src/Presets/Tailwind.php
+++ b/src/Presets/Tailwind.php
@@ -8,6 +8,8 @@ class Tailwind extends Preset
     protected function updatePackagesArray(array $packages)
     {
         $packages['devDependencies']['tailwindcss'] = '^2.0.1';
+        $packages['devDependencies']['postcss'] = '^8.0.9';
+        $packages['devDependencies']['autoprefixer'] = '^10.0.2';
 
         return $packages;
     }


### PR DESCRIPTION
Follow up to #40

Tailwind 2 has two peer deps:

1. PostCSS 8
2. Autoprefixer 10

In reality, only the missing PostCSS dep will cause building to fail, but I thought I should just add both to be safe.